### PR TITLE
#Issue32: Add authentication token in header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wis2-downloader",
   "productName": "WIS2 Downloader",
-  "version": "0.2.1",
+  "version": "0.2.dev1",
   "description": "This standalone application allows you to connect to WIS2 global brokers, explore the Global Discovery Catalogues and download data from the WIS2 network.",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wis2-downloader",
   "productName": "WIS2 Downloader",
-  "version": "0.2.dev1",
+  "version": "0.2.1",
   "description": "This standalone application allows you to connect to WIS2 global brokers, explore the Global Discovery Catalogues and download data from the WIS2 network.",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -183,10 +183,8 @@ export default defineComponent({
         const jsonDialog = ref(false);
 
         // Information from Subscribe page
-        const host = ref('');
-        const port = ref('');
-        const username = ref('');
-        const password = ref('');
+        const serverLink = ref('');
+        const token = ref('');
         const connectionStatus = ref(false);
         const activeTopics = ref([]);
         const pendingTopics = ref([]);
@@ -200,10 +198,8 @@ export default defineComponent({
         // Stored settings from Subscribe page
         const settings = computed(() => {
             return {
-                host: host.value,
-                port: port.value,
-                username: username.value,
-                password: password.value,
+                serverLink: serverLink.value,
+                token: token.value,
                 connectionStatus: connectionStatus.value,
                 activeTopics: activeTopics.value,
                 pendingTopics: pendingTopics.value
@@ -227,10 +223,8 @@ export default defineComponent({
             try {
                 const storedSettings = await window.electronAPI.loadSettings();
                 if (storedSettings) {
-                    host.value = storedSettings?.host || '';
-                    port.value = storedSettings?.port || '';
-                    username.value = storedSettings?.username || '';
-                    password.value = storedSettings?.password || '';
+                    serverLink.value = storedSettings?.serverLink || '';
+                    token.value = storedSettings?.token || '';
                     connectionStatus.value = storedSettings?.connectionStatus || false;
                     activeTopics.value = storedSettings?.activeTopics || [];
                     pendingTopics.value = storedSettings?.pendingTopics || [];

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,9 +1,5 @@
-const { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain, dialog } = require("electron");
+const { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain } = require("electron");
 const path = require("path");
-const fs = require('fs');
-const spawn = require('child_process').spawn;
-const kill = require('tree-kill');
-let backendProcess = null;
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require("electron-squirrel-startup")) {
@@ -42,7 +38,7 @@ const createWindow = () => {
   mainWindow.webContents.insertCSS("body::-webkit-scrollbar { display: none !important; }");
 
   // Always minimise to tray
-  mainWindow.on('minimize',function(event){
+  mainWindow.on('minimize',function(event) {
     event.preventDefault();
     mainWindow.hide();
   });


### PR DESCRIPTION
The connection to the downloader API has been re-organised to enable authentication:
- Server host and port fields have been united into one 'Server link' field.
- Redundant username and password fields have been replaced by 'API token' field that is used in the header of each GET request.
- If the API token is invalid on initial connection, the user is specifically informed about this.