### PR TITLE
#Issue28: Hide dataset buttons when not connected to downloader backend

### DIFF
--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -52,7 +52,7 @@
                                 </th>
                                 <th scope="row" class="button-column">
                                     <v-row justify="center" class="pa-2"
-                                        v-if="tableBoolean === true && connectionStatus === true">
+                                        v-if="tableBoolean === true && connectionStatus">
                                         <v-switch inset label="Add All" v-model="addAllTopics"
                                             @change="addOrRemoveAllTopics(datasets, addAllTopics)"
                                             :disabled="tableBoolean === false" color="#003DA5" />
@@ -70,19 +70,19 @@
                                     <td>
                                         <!-- If topic not added, allow them to add -->
                                         <v-btn block
-                                            v-if="!topicFound(item.topic_hierarchy, selectedTopics) && item.topic_hierarchy && connectionStatus === true"
+                                            v-if="!topicFound(item.topic_hierarchy, selectedTopics) && item.topic_hierarchy && connectionStatus"
                                             color="#64BF40" append-icon="mdi-plus" variant="flat"
                                             @click.stop="addTopicToPending(item)">
                                             Add</v-btn>
                                         <v-btn block
-                                            v-if="topicFound(item.topic_hierarchy, pendingTopics) && connectionStatus === true"
+                                            v-if="topicFound(item.topic_hierarchy, pendingTopics) && connectionStatus"
                                             color="error" append-icon="mdi-minus" variant="flat"
                                             @click.stop="removeTopicFromPending(item)">
                                             Remove</v-btn>
                                         <v-btn block v-if="topicFound(item.topic_hierarchy, activeTopics)" disabled
                                             color="#003DA5" append-icon="mdi-download-multiple" variant="flat">
                                             Active</v-btn>
-                                        <v-btn block v-if="!item.topic_hierarchy && connectionStatus === true" disabled variant="flat">
+                                        <v-btn block v-if="!item.topic_hierarchy && connectionStatus" disabled variant="flat">
                                             No Topic</v-btn>
                                     </td>
                                 </tr>

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -5,7 +5,7 @@
                 <v-toolbar dense>
                     <v-toolbar-title class="big-title">Search a WIS2 Global Discovery Catalogue</v-toolbar-title>
                 </v-toolbar>
-                <v-card-subtitle>Find datasets to add to your list of pending subscriptions</v-card-subtitle>
+                <v-card-subtitle>Explore and find datasets to add to your list of pending subscriptions</v-card-subtitle>
 
                 <v-col cols="12" />
 
@@ -51,7 +51,8 @@
                                     <p class="medium-title">Discovery Metadata Records Found</p>
                                 </th>
                                 <th scope="row" class="button-column">
-                                    <v-row justify="center" class="pa-2" v-if="tableBoolean === true">
+                                    <v-row justify="center" class="pa-2"
+                                        v-if="tableBoolean === true && connectionStatus === true">
                                         <v-switch inset label="Add All" v-model="addAllTopics"
                                             @change="addOrRemoveAllTopics(datasets, addAllTopics)"
                                             :disabled="tableBoolean === false" color="#003DA5" />
@@ -69,18 +70,19 @@
                                     <td>
                                         <!-- If topic not added, allow them to add -->
                                         <v-btn block
-                                            v-if="!topicFound(item.topic_hierarchy, selectedTopics) && item.topic_hierarchy"
+                                            v-if="!topicFound(item.topic_hierarchy, selectedTopics) && item.topic_hierarchy && connectionStatus === true"
                                             color="#64BF40" append-icon="mdi-plus" variant="flat"
                                             @click.stop="addTopicToPending(item)">
                                             Add</v-btn>
-                                        <v-btn block v-if="topicFound(item.topic_hierarchy, pendingTopics)"
+                                        <v-btn block
+                                            v-if="topicFound(item.topic_hierarchy, pendingTopics) && connectionStatus === true"
                                             color="error" append-icon="mdi-minus" variant="flat"
                                             @click.stop="removeTopicFromPending(item)">
                                             Remove</v-btn>
                                         <v-btn block v-if="topicFound(item.topic_hierarchy, activeTopics)" disabled
                                             color="#003DA5" append-icon="mdi-download-multiple" variant="flat">
                                             Active</v-btn>
-                                        <v-btn block v-if="!item.topic_hierarchy" disabled variant="flat">
+                                        <v-btn block v-if="!item.topic_hierarchy && connectionStatus === true" disabled variant="flat">
                                             No Topic</v-btn>
                                     </td>
                                 </tr>
@@ -166,7 +168,7 @@ export default defineComponent({
         // Static variables
         const catalogueList = [
             { title: 'Meteorological Service of Canada', url: 'https://api.weather.gc.ca/collections/wis2-discovery-metadata/items' },
-            { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/collections/wis2-discovery-metadata/items' }
+            { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/collections/wis2-discovery-metadata/items?f=json' }
         ];
 
         // Reactive variables

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -6,7 +6,7 @@
                     <v-toolbar-title class="big-title">WIS2 Subscription Dashboard</v-toolbar-title>
                     <v-toolbar-items class="sync-time pa-5">
                         <transition name="fade-transition">
-                            <p v-if="connectionStatus">Last synchronized: <b>{{ lastSyncTime }}</b></p>
+                            <p v-if="connectedToDownloader">Last synchronized: <b>{{ lastSyncTime }}</b></p>
                         </transition>
                     </v-toolbar-items>
                 </v-toolbar>
@@ -21,20 +21,20 @@
                             <v-row>
                                 <v-col cols="5">
                                     <v-text-field v-model="serverLink" label="Server URL"
-                                        :disabled="connectionStatus"></v-text-field>
+                                        :disabled="connectedToDownloader"></v-text-field>
                                 </v-col>
                                 <v-col cols="4">
                                     <v-text-field v-model="token" label="API Token"
-                                        :disabled="connectionStatus"></v-text-field>
+                                        :disabled="connectedToDownloader"></v-text-field>
                                 </v-col>
                                 <v-col cols="3">
                                     <!-- Before connecting -->
-                                    <v-btn v-if="!connectionStatus" color="#003DA5" size="x-large" block
+                                    <v-btn v-if="!connectedToDownloader" color="#003DA5" size="x-large" block
                                         append-icon="mdi-link" @click="getServerData"
                                         :loading="connectingToServer">Connect</v-btn>
 
                                     <!-- After connecting -->
-                                    <v-row v-if="connectionStatus" dense>
+                                    <v-row v-if="connectedToDownloader" dense>
                                         <template v-if="lgAndUp">
                                             <v-col cols="5">
                                                 <v-btn color="#00ABC9" size="x-large" block
@@ -70,7 +70,7 @@
                 <v-col cols="12" />
 
                 <transition name="slide-y-transition">
-                    <v-card-item v-if="connectionStatus">
+                    <v-card-item v-if="connectedToDownloader">
                         <v-divider class="pa-3" />
 
                         <v-row>
@@ -497,7 +497,7 @@ export default defineComponent({
         // Server information
         const serverLink = ref('127.0.0.1:8080');
         const token = ref('')
-        const connectionStatus = ref(false);
+        const connectedToDownloader = ref(false);
 
         // The topics (as keys) and their associated targets (as values)
         const activeTopics = ref([]);
@@ -544,7 +544,7 @@ export default defineComponent({
             return {
                 serverLink: serverLink.value,
                 token: token.value,
-                connectionStatus: connectionStatus.value,
+                connectedToDownloader: connectedToDownloader.value,
                 activeTopics: activeTopics.value,
                 pendingTopics: pendingTopics.value
             }
@@ -565,7 +565,7 @@ export default defineComponent({
                 if (storedSettings) {
                     serverLink.value = storedSettings?.serverLink || '127.0.0.1:8080';
                     token.value = storedSettings?.token || '';
-                    connectionStatus.value = storedSettings?.connectionStatus || false;
+                    connectedToDownloader.value = storedSettings?.connectedToDownloader || false;
                     activeTopics.value = storedSettings?.activeTopics || [];
                     pendingTopics.value = storedSettings?.pendingTopics || [];
                 }
@@ -615,7 +615,7 @@ export default defineComponent({
                     }
                     errorTitle.value = "Error Listing Topics";
                     showErrorDialog.value = true;
-                    connectionStatus.value = false;
+                    connectedToDownloader.value = false;
                     return;
                 }
 
@@ -626,13 +626,13 @@ export default defineComponent({
                 activeTopics.value = processTopicData(data);
 
                 // Display the table of active/pending topics
-                connectionStatus.value = true;
+                connectedToDownloader.value = true;
             }
             catch (error) {
                 errorMessage.value = `There was a problem connecting to the server (${error}). Please check the server is running and the settings are correct.`;
                 errorTitle.value = "Server Error";
                 showErrorDialog.value = true;
-                connectionStatus.value = false;
+                connectedToDownloader.value = false;
             }
         };
 
@@ -683,7 +683,7 @@ export default defineComponent({
             await getMetrics();
 
             // If the connection is successful, update the last sync time
-            if (connectionStatus.value) {
+            if (connectedToDownloader.value) {
                 lastSyncTime.value = new Date().toLocaleTimeString();
             }
 
@@ -693,7 +693,7 @@ export default defineComponent({
 
         // Clear the server data and reset the connection status
         const clearServerData = () => {
-            connectionStatus.value = false;
+            connectedToDownloader.value = false;
             activeTopics.value = [];
         };
 
@@ -1033,7 +1033,7 @@ export default defineComponent({
             // Get settings from GDC or previous usage of configuration page
             loadSettings();
             // If the connection is already established, get the topic list every 5 minutes
-            if (connectionStatus.value) {
+            if (connectedToDownloader.value) {
                 setInterval(getServerData, 5 * 60 * 1000);
             }
         });
@@ -1059,7 +1059,7 @@ export default defineComponent({
             // Reactive variables
             serverLink,
             token,
-            connectionStatus,
+            connectedToDownloader,
             activeTopics,
             pendingTopics,
             metrics,


### PR DESCRIPTION
**Main Changes**
- The 'Add All', 'Add', 'Remove', 'Active', 'No Topic' buttons are now hidden when the user has not yet connected to their downloader backend.

**Minor Changes**
- The `connectionStatus` boolean has been renamed to `connectedToBackend` to read more intuitively in the template section.