### PR TITLE
Improve Display of Results from GDC

### DIFF
--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -5,7 +5,8 @@
                 <v-toolbar dense>
                     <v-toolbar-title class="big-title">Search a WIS2 Global Discovery Catalogue</v-toolbar-title>
                 </v-toolbar>
-                <v-card-subtitle>Explore and find datasets to add to your list of pending subscriptions</v-card-subtitle>
+                <v-card-subtitle>Explore and find datasets to add to your list of pending
+                    subscriptions</v-card-subtitle>
 
                 <v-col cols="12" />
 
@@ -64,8 +65,20 @@
                             <tbody v-show="tableBoolean === true">
                                 <tr v-for="item in datasets" :key="item.title" @click="openDialog(item)"
                                     class="clickable-row">
-                                    <td class="small-title">
-                                        {{ item.title }}
+                                    <td class="small-title py-3">
+                                        <div class="title-section">
+                                            <span><b>{{ item.centre_identifier }}:</b> {{ item.title }}</span>
+                                            <span class="policy-section">({{ item.data_policy }})</span>
+                                        </div>
+                                        <div class="keywords-section">
+                                            <p><b>Keywords:</b> {{ item.keywords }}</p>
+                                        </div>
+                                        <div class="date-section">
+                                            <p><b>Creation Date:</b> {{ item.creation_date }}</p>
+                                        </div>
+                                        <div class="description-section">
+                                            <p>{{ item.description }}</p>
+                                        </div>
                                     </td>
                                     <td>
                                         <!-- If topic not added, allow them to add -->
@@ -82,7 +95,8 @@
                                         <v-btn block v-if="topicFound(item.topic_hierarchy, activeTopics)" disabled
                                             color="#003DA5" append-icon="mdi-download-multiple" variant="flat">
                                             Active</v-btn>
-                                        <v-btn block v-if="!item.topic_hierarchy && connectionStatus" disabled variant="flat">
+                                        <v-btn block v-if="!item.topic_hierarchy && connectionStatus" disabled
+                                            variant="flat">
                                             No Topic</v-btn>
                                     </td>
                                 </tr>
@@ -110,7 +124,8 @@
                                 <v-row>
                                     <v-col cols="12">
                                         <v-btn color="#E09D00" append-icon="mdi-code-json" variant="flat" block
-                                            @click="openJSON(selectedItem.identifier, selectedItem.title)" :loading="loadingJsonBoolean">
+                                            @click="openJSON(selectedItem.identifier, selectedItem.title)"
+                                            :loading="loadingJsonBoolean">
                                             View JSON
                                         </v-btn>
                                     </v-col>
@@ -256,7 +271,7 @@ export default defineComponent({
                 }
                 return await response.json();
             } catch (error) {
-            throw new Error(`There was an error connecting to the catalogue: ${error.message}`);
+                throw new Error(`There was an error connecting to the catalogue: ${error.message}`);
             }
         };
 
@@ -325,14 +340,40 @@ export default defineComponent({
                     }
                 }
 
+                // Format data policy to begin with a captial
+                let data_policy;
+                if (properties?.['wmo:dataPolicy']) {
+                    data_policy = properties['wmo:dataPolicy'].charAt(0).toUpperCase() + properties['wmo:dataPolicy'].slice(1);
+                }
+
+                // Earth system discipline is the id item of concept whose scheme is
+                // "https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+                let discipline;
+                if (properties?.themes) {
+                    const earthSystemDiscipline = properties.themes.find(theme => theme.scheme === 'https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline');
+                    if (earthSystemDiscipline) {
+                        discipline = earthSystemDiscipline.concepts[0]?.id;
+                    }
+                }
+
+
+                // Truncate description to 120 characters
+                let description;
+                if (properties?.description) {
+                    description = properties.description.substring(0, 120) + '...';
+                }
+
                 return {
                     identifier: identifier || 'No identifier found',
                     centre_identifier: centre_id || 'No centre identifier found',
                     title: properties?.title || 'No title found',
                     creation_date: properties?.created || 'No creation date found',
+                    last_update: properties?.updated || 'No updates',
                     topic_hierarchy: topic_hierarchy || 'No topic hierarchy found',
-                    data_policy: properties?.['wmo:dataPolicy'] || 'No data policy found',
-                    description: properties.description.substring(0, 100) + '...' || 'No description found'
+                    data_policy: data_policy || 'No data policy found',
+                    keywords: properties?.keywords?.join(', ') || 'None found',
+                    earth_system_discipline: discipline || 'No discipline found',
+                    description: description || 'No description found'
                 }
             });
 
@@ -553,5 +594,33 @@ export default defineComponent({
 
 .button-column {
     width: 17%;
+}
+
+.title-section {
+    font-size: 1rem;
+}
+
+.policy-section {
+    margin-left: 0.5rem;
+    color: #888;
+}
+
+.keywords-section {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: #555;
+    font-style: italic;
+}
+
+.date-section {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: #555;
+}
+
+.description-section {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: #888;
 }
 </style>

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -296,7 +296,7 @@ export default defineComponent({
 
                 // Initialise other features we want to extract
                 let topic_hierarchy = null;
-                let center_id = null;
+                let centre_id = null;
 
                 // The topic hierarchy is found in the 'channel'
                 // property in 'links' where the 'rel' is 'items'
@@ -316,21 +316,23 @@ export default defineComponent({
                 if (identifier) {
                     if (identifier.includes(':')) {
                         const tokens = identifier.split(':');
-                        center_id = tokens.length < 5 ? tokens[1] : tokens[3];
+                        centre_id = tokens.length < 5 ? tokens[1] : tokens[3];
                     }
 
                     else {
                         const tokens = identifier.split('.');
-                        center_id = tokens[1];
+                        centre_id = tokens[1];
                     }
                 }
+
                 return {
-                    identifier: identifier,
-                    center_identifier: center_id,
-                    title: properties?.title,
-                    creation_date: properties?.created,
-                    topic_hierarchy: topic_hierarchy,
-                    data_policy: properties?.['wmo:dataPolicy'],
+                    identifier: identifier || 'No identifier found',
+                    centre_identifier: centre_id || 'No centre identifier found',
+                    title: properties?.title || 'No title found',
+                    creation_date: properties?.created || 'No creation date found',
+                    topic_hierarchy: topic_hierarchy || 'No topic hierarchy found',
+                    data_policy: properties?.['wmo:dataPolicy'] || 'No data policy found',
+                    description: properties.description.substring(0, 100) + '...' || 'No description found'
                 }
             });
 

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -730,7 +730,7 @@ export default defineComponent({
                     const errorData = await response.json();
                     const readableError = HTTP_CODES[response.status] || response.statusText;
                     // Display the error message from server response, if available
-                    const message = errorData.error ? errorData.error : readableError;
+                    const message = errorData.error || readableError;
                     handleError('Error Adding Topic', message);
                     // End the button loading animation for this topic
                     makingServerRequest.value[item.topic] = false;
@@ -781,7 +781,7 @@ export default defineComponent({
                     const errorData = await response.json();
                     const readableError = HTTP_CODES[response.status] || response.statusText;
                     // Display the error message from server response, if available
-                    const message = errorData.error ? errorData.error : readableError;
+                    const message = errorData.error || readableError;
                     handleError('Error Removing Topic', message);
                     // End the button loading animation for this topic
                     makingServerRequest.value[topic] = false;

--- a/src/frontend/styles/settings.scss
+++ b/src/frontend/styles/settings.scss
@@ -20,6 +20,10 @@
     max-width: 1000px;
 }
 
+.max-dataset-width {
+    max-width: 1200px;
+}
+
 .max-error-width {
     max-width: 800px;
 }
@@ -121,4 +125,8 @@
     font-weight: 800;
     font-size: 1.5rem;
     margin-left: 1rem;
+}
+
+.align-top {
+    vertical-align: top;
 }


### PR DESCRIPTION
**Major Changes**
- The centre id, data policy, truncated description, keywords, and creation date are all shown for each result when browsing, making it easier to quickly understand the results of your search.
- These features, as well as earth system discipline and update date, are also shown in the dataset preview (when a result is clicked). Here the description is shown in full.

**Minor Changes**
- Alignment and spacing improvements of the dataset preview.
- If a feature cannot be found, it is stated clearly instead of shown blank.