### PR TITLE
fix: improved handling of active and pending topic dialogs

### DIFF
--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -256,7 +256,7 @@ export default defineComponent({
                     handleError('Error Loading Settings', 'There was an issue loading the settings or topics you selected. Please try reloading the application.');
                     return;
                 }
-                serverLink.value = storedSettings?.serverLink || '';
+                serverLink.value = storedSettings?.serverLink || 'http://localhost:5050';
                 token.value = storedSettings?.token || '';
                 connectionStatus.value = storedSettings?.connectionStatus || false;
                 activeTopics.value = storedSettings?.activeTopics || [];

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -5,8 +5,12 @@
                 <v-toolbar dense>
                     <v-toolbar-title class="big-title">Search a WIS2 Global Discovery Catalogue</v-toolbar-title>
                 </v-toolbar>
-                <v-card-subtitle>Explore and find datasets to add to your list of pending
-                    subscriptions</v-card-subtitle>
+                <v-card-subtitle>
+                    Explore and find datasets to add to your list of pending
+                    subscriptions.
+                    <br>
+                    If you have not yet connected to a WIS2 Downloader, you will only be able to view the datasets.
+                </v-card-subtitle>
 
                 <v-col cols="12" />
 

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -67,7 +67,7 @@
                                     class="clickable-row">
                                     <td class="small-title py-3">
                                         <div class="title-section">
-                                            <span><b v-if="centreFound(item)">{{ item.centre_identifier }}:</b> {{ item.title }}</span>
+                                            <span><b v-if="item.centre_identifier">{{ item.centre_identifier }}:</b> {{ item.title }}</span>
                                             <span class="policy-section">({{ item.data_policy }})</span>
                                         </div>
                                         <div class="description-section">
@@ -116,7 +116,7 @@
                                         <tr v-if="key !== 'title'" class="align-top">
                                             <td class="feature-column"><b>{{ formatKey(key) }}</b></td>
                                             <td><v-divider vertical/></td>
-                                            <td>{{ value }}</td>
+                                            <td>{{ formatValue(value) }}</td>
                                         </tr>
                                     </tbody>
                                 </template>
@@ -233,11 +233,6 @@ export default defineComponent({
         const selectedTopics = computed(() => {
             return [...activeTopics.value, ...pendingTopics.value];
         });
-
-        // Check a dataset's centre identifier is found
-        const centreFound = (item) => {
-            return item.centre_identifier !== 'No centre identifier found';
-        }
 
         // Methods
 
@@ -368,16 +363,16 @@ export default defineComponent({
                 }
 
                 return {
-                    identifier: identifier || 'No identifier found',
-                    centre_identifier: centre_id || 'No centre identifier found',
-                    title: properties?.title || 'No title found',
-                    creation_date: properties?.created || 'No creation date found',
-                    last_update: properties?.updated || 'No updates',
-                    topic_hierarchy: topic_hierarchy || 'No topic hierarchy found',
-                    data_policy: data_policy || 'No data policy found',
-                    keywords: properties?.keywords?.join(', ') || 'None found',
-                    earth_system_discipline: discipline || 'No discipline found',
-                    description: properties.description || 'No description found'
+                    identifier: identifier,
+                    centre_identifier: centre_id,
+                    title: properties?.title,
+                    creation_date: properties?.created,
+                    last_update: properties?.updated,
+                    topic_hierarchy: topic_hierarchy,
+                    data_policy: data_policy,
+                    keywords: properties?.keywords?.join(', '),
+                    earth_system_discipline: discipline,
+                    description: properties.description
                 }
             });
 
@@ -408,6 +403,11 @@ export default defineComponent({
                 .split(' ')
                 .map(word => word.charAt(0).toUpperCase() + word.slice(1))
                 .join(' ');
+        }
+
+        // Format the value of this key to show 'N/A' if it is null
+        const formatValue = (value) => {
+            return value ? value : 'N/A';
         }
 
         // Opens JSON of dataset metadata
@@ -575,12 +575,12 @@ export default defineComponent({
             // Computed variables
             catalogueBoolean,
             selectedTopics,
-            centreFound,
 
             // Methods
             searchCatalogue,
             openDialog,
             formatKey,
+            formatValue,
             openJSON,
             topicFound,
             addTopicToPending,

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -53,7 +53,7 @@
                                 </th>
                                 <th scope="row" class="button-column">
                                     <v-row justify="center" class="pa-2"
-                                        v-if="tableBoolean === true && connectionStatus">
+                                        v-if="tableBoolean === true && connectedToDownloader">
                                         <v-switch inset label="Add All" v-model="addAllTopics"
                                             @change="addOrRemoveAllTopics(datasets, addAllTopics)"
                                             :disabled="tableBoolean === false" color="#003DA5" />
@@ -83,19 +83,19 @@
                                     <td>
                                         <!-- If topic not added, allow them to add -->
                                         <v-btn block
-                                            v-if="!topicFound(item.topic_hierarchy, selectedTopics) && item.topic_hierarchy && connectionStatus"
+                                            v-if="!topicFound(item.topic_hierarchy, selectedTopics) && item.topic_hierarchy && connectedToDownloader"
                                             color="#64BF40" append-icon="mdi-plus" variant="flat"
                                             @click.stop="addTopicToPending(item)">
                                             Add</v-btn>
                                         <v-btn block
-                                            v-if="topicFound(item.topic_hierarchy, pendingTopics) && connectionStatus"
+                                            v-if="topicFound(item.topic_hierarchy, pendingTopics) && connectedToDownloader"
                                             color="error" append-icon="mdi-minus" variant="flat"
                                             @click.stop="removeTopicFromPending(item)">
                                             Remove</v-btn>
                                         <v-btn block v-if="topicFound(item.topic_hierarchy, activeTopics)" disabled
                                             color="#003DA5" append-icon="mdi-download-multiple" variant="flat">
                                             Active</v-btn>
-                                        <v-btn block v-if="!item.topic_hierarchy && connectionStatus" disabled
+                                        <v-btn block v-if="!item.topic_hierarchy && connectedToDownloader" disabled
                                             variant="flat">
                                             No Topic</v-btn>
                                     </td>
@@ -110,7 +110,7 @@
                             <v-toolbar :title="selectedItem.title" color="#003DA5">
                                 <v-btn icon="mdi-close" variant="text" @click="dialog = false" />
                             </v-toolbar>
-                            <v-table class="px-4 py-7">
+                            <v-table class="px-4 py-7 scrollable-table">
                                 <template v-for="(value, key) in selectedItem">
                                     <tbody>
                                         <tr v-if="key !== 'title'" class="align-top">
@@ -203,7 +203,7 @@ export default defineComponent({
         // Information from Subscribe page
         const serverLink = ref('');
         const token = ref('');
-        const connectionStatus = ref(false);
+        const connectedToDownloader = ref(false);
         const activeTopics = ref([]);
         const pendingTopics = ref([]);
 
@@ -218,7 +218,7 @@ export default defineComponent({
             return {
                 serverLink: serverLink.value,
                 token: token.value,
-                connectionStatus: connectionStatus.value,
+                connectedToDownloader: connectedToDownloader.value,
                 activeTopics: activeTopics.value,
                 pendingTopics: pendingTopics.value
             }
@@ -258,7 +258,7 @@ export default defineComponent({
                 }
                 serverLink.value = storedSettings?.serverLink || 'http://localhost:5050';
                 token.value = storedSettings?.token || '';
-                connectionStatus.value = storedSettings?.connectionStatus || false;
+                connectedToDownloader.value = storedSettings?.connectedToDownloader || false;
                 activeTopics.value = storedSettings?.activeTopics || [];
                 pendingTopics.value = storedSettings?.pendingTopics || [];
             }
@@ -566,7 +566,7 @@ export default defineComponent({
             formattedJson,
             loadingJsonBoolean,
             jsonDialog,
-            connectionStatus,
+            connectedToDownloader,
             activeTopics,
             pendingTopics,
             errorMessage,
@@ -631,6 +631,12 @@ export default defineComponent({
 
 .feature-column {
     width: 15%
+}
+
+.scrollable-table
+{
+    max-height: 600px;
+    overflow-y: auto;
 }
 
 </style>

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -495,7 +495,7 @@ export default defineComponent({
         // Reactive variables
 
         // Server information
-        const serverLink = ref('127.0.0.1:8080');
+        const serverLink = ref('http://localhost:5050');
         const token = ref('')
         const connectedToDownloader = ref(false);
 
@@ -578,7 +578,7 @@ export default defineComponent({
                     handleError('Error Loading Settings', 'There was an issue loading the settings or topics you selected. Please try reloading the application.');
                     return;
                 }
-                serverLink.value = storedSettings.serverLink || '127.0.0.1:8080';
+                serverLink.value = storedSettings.serverLink || 'http://localhost:5050';
                 token.value = storedSettings.token || '';
                 connectedToDownloader.value = storedSettings.connectedToDownloader || false;
                 activeTopics.value = storedSettings.activeTopics || [];
@@ -607,10 +607,10 @@ export default defineComponent({
         // Get the topics and their associated targets from the /list endpoint
         const getTopicList = async () => {
             try {
-                const response = await fetch(subscribeLink, {
+                const response = await fetch(subscribeLink.value, {
                     method: 'GET',
                     headers: {
-                        'accept': 'application/json',
+                        'Accept': 'application/json',
                         'Authorization': 'Bearer ' + token.value
                     }
                 });
@@ -653,7 +653,7 @@ export default defineComponent({
                 const response = await fetch(metricsLink, {
                     method: 'GET',
                     headers: {
-                        'accept': 'text/plain',
+                        'Accept': 'text/plain',
                         'Authorization': 'Bearer ' + token.value
                     },
                 });
@@ -723,10 +723,10 @@ export default defineComponent({
             };
 
             try {
-                const response = await fetch(subscribeLink, {
+                const response = await fetch(subscribeLink.value, {
                     method: 'POST',
                     headers: {
-                        'accept': 'application/json',
+                        'Accept': 'application/json',
                         'Content-Type': 'application/json',
                         'Authorization': 'Bearer ' + token.value
                     },
@@ -773,7 +773,7 @@ export default defineComponent({
             const encodedTopic = encodeURIComponent(topic);
 
             // Build the full URL for deleting a subscription
-            const deleteLink = `${subscribeLink}/${encodedTopic}`;
+            const deleteLink = `${subscribeLink.value}/${encodedTopic}`;
 
             try {
                 const response = await fetch(deleteLink, {
@@ -1093,6 +1093,7 @@ export default defineComponent({
             // Computed variables
             settings,
             topicHasMetrics,
+            subscribeLink,
 
             // Methods
             processTopicData,

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -37,26 +37,22 @@
                                     <v-row v-if="connectedToDownloader" dense>
                                         <template v-if="lgAndUp">
                                             <v-col cols="5">
-                                                <v-btn color="#00ABC9" size="x-large" block
-                                                    append-icon="mdi-sync" @click="getServerData"
-                                                    :loading="connectingToServer">Sync</v-btn>
+                                                <v-btn color="#00ABC9" size="x-large" block append-icon="mdi-sync"
+                                                    @click="getServerData" :loading="connectingToServer">Sync</v-btn>
                                             </v-col>
                                             <v-col cols="7">
-                                                <v-btn color="#E09D00" size="x-large" block
-                                                    append-icon="mdi-link-off" @click="clearServerData"
-                                                    :loading="connectingToServer">Disconnect</v-btn>
+                                                <v-btn color="#E09D00" size="x-large" block append-icon="mdi-link-off"
+                                                    @click="clearServerData">Disconnect</v-btn>
                                             </v-col>
                                         </template>
                                         <template v-else>
                                             <v-col cols="12">
-                                                <v-btn color="#00ABC9" block
-                                                    append-icon="mdi-sync" @click="getServerData"
-                                                    :loading="connectingToServer">Sync</v-btn>
+                                                <v-btn color="#00ABC9" block append-icon="mdi-sync"
+                                                    @click="getServerData" :loading="connectingToServer">Sync</v-btn>
                                             </v-col>
                                             <v-col cols="12">
-                                                <v-btn color="#E09D00" block
-                                                    append-icon="mdi-link-off" @click="clearServerData"
-                                                    :loading="connectingToServer">Disconnect</v-btn>
+                                                <v-btn color="#E09D00" block append-icon="mdi-link-off"
+                                                    @click="clearServerData">Disconnect</v-btn>
                                             </v-col>
                                         </template>
                                     </v-row>
@@ -111,7 +107,7 @@
                                         </thead>
                                         <tbody>
                                             <tr v-for="item in activeTopics" :key="item.topic"
-                                                @click="configureTopic(item)" class="clickable-row">
+                                                @click="configureTopic('active', item)" class="clickable-row">
                                                 <td class="small-title">
                                                     {{ item.topic }}
                                                 </td>
@@ -119,12 +115,14 @@
                                                     {{ item.target }}
                                                 </td>
                                                 <td class="text-center">
-                                                    <v-btn class="mr-5" :append-icon="lgAndUp ? 'mdi-chart-box' : ''" color="#00ABC9"
-                                                        variant="flat" @click.stop="monitorTopic(item.topic)">
+                                                    <v-btn class="mr-5" :append-icon="lgAndUp ? 'mdi-chart-box' : ''"
+                                                        color="#00ABC9" variant="flat"
+                                                        @click.stop="monitorTopic(item.topic)">
                                                         <p v-if="mdAndUp">Monitor</p>
                                                         <v-icon v-if="!mdAndUp" icon="mdi-chart-box" />
                                                     </v-btn>
-                                                    <v-btn :append-icon="lgAndUp ? 'mdi-delete' : ''" color="error" variant="flat"
+                                                    <v-btn :append-icon="lgAndUp ? 'mdi-delete' : ''" color="error"
+                                                        variant="flat"
                                                         @click.stop="confirmRemoval(item.topic, 'active')">
                                                         <p v-if="mdAndUp">Remove</p>
                                                         <v-icon v-if="!mdAndUp" icon="mdi-chart-box" />
@@ -164,14 +162,14 @@
                                                         Actions
                                                     </p>
                                                     <v-btn v-else block color="#64BF40" append-icon="mdi-plus"
-                                                        @click="configureTopic()">Add A
+                                                        @click="configureTopic('pending')">Add A
                                                         Topic</v-btn>
                                                 </th>
                                             </tr>
                                         </thead>
                                         <tbody>
                                             <tr v-for="item in pendingTopics" :key="item.topic"
-                                                @click="configureTopic(item)" class="clickable-row">
+                                                @click="configureTopic('pending', item)" class="clickable-row">
                                                 <td class="small-title">
                                                     {{ item.topic }}
                                                 </td>
@@ -179,13 +177,15 @@
                                                     {{ item.target }}
                                                 </td>
                                                 <td class="text-center">
-                                                    <v-btn class="mr-5" :append-icon="lgAndUp ? 'mdi-cloud-upload' : ''" color="#003DA5"
-                                                        variant="flat" @click.stop="addToSubscription(item)"
+                                                    <v-btn class="mr-5" :append-icon="lgAndUp ? 'mdi-cloud-upload' : ''"
+                                                        color="#003DA5" variant="flat"
+                                                        @click.stop="addToSubscription(item)"
                                                         :loading="makingServerRequest[item.topic]">
                                                         <p v-if="mdAndUp">Activate</p>
                                                         <v-icon v-if="!mdAndUp" icon="mdi-cloud-upload" />
                                                     </v-btn>
-                                                    <v-btn :append-icon="lgAndUp ? 'mdi-delete' : ''" color="error" variant="flat"
+                                                    <v-btn :append-icon="lgAndUp ? 'mdi-delete' : ''" color="error"
+                                                        variant="flat"
                                                         @click.stop="confirmRemoval(item.topic, 'pending')">
                                                         <p v-if="mdAndUp">Remove</p>
                                                         <v-icon v-if="!mdAndUp" icon="mdi-delete" />
@@ -200,7 +200,7 @@
                                         <v-row>
                                             <v-col cols="6">
                                                 <v-btn v-if="pendingTopics.length > 0" block color="#64BF40"
-                                                    append-icon="mdi-plus" @click="configureTopic()">Add A
+                                                    append-icon="mdi-plus" @click="configureTopic('pending')">Add A
                                                     New Topic</v-btn>
                                             </v-col>
                                             <v-col cols="6">
@@ -227,65 +227,58 @@
             <v-toolbar :title="topicDialogTitle" color="#003DA5">
                 <v-btn icon="mdi-close" variant="text" size="small" @click="showTopicConfigDialog = false" />
             </v-toolbar>
-            <v-container>
-                <v-form @submit.prevent="saveTopic">
-                    <v-col cols="12">
-                        <v-row>
-                            <v-col cols="12">
+            <v-sheet class="mx-auto py-5" width="95%">
+                <!-- Pending topics -->
+                <v-form ref="form" v-if="configuredTopicIsPending">
+                    <v-text-field v-model="topicToAdd" label="Topic" :rules="[rules.required, rules.topic]" />
 
-                                <!-- If active topic -->
-                                <v-row v-if="topicFound(topicToAdd, activeTopics)" class="pb-5">
-                                    <v-col cols="2">
-                                        <p class="medium-title"><b>Topic:</b></p>
-                                    </v-col>
-                                    <v-col cols="10">
-                                        <p class="medium-title">{{ topicToAdd }}</p>
-                                    </v-col>
-                                </v-row>
+                    <v-text-field v-model="targetToAdd" label="Associated Sub-Directory"
+                        :rules="[rules.required, rules.target]" />
 
-                                <v-divider />
-
-                                <v-row v-if="topicFound(topicToAdd, activeTopics)" class="pt-5">
-                                    <v-col cols="2">
-                                        <p class="medium-title"><b>Target:</b></p>
-                                    </v-col>
-                                    <v-col cols="8">
-                                        <!-- Target switches between read-only and editable -->
-                                        <p v-if="!editActiveTarget" class="medium-title">{{ targetToAdd }}</p>
-                                        <v-text-field v-else v-model="targetToAdd" density="comfortable"
-                                            variant="outlined" clearable :rules="[rules.required, rules.target]" />
-                                    </v-col>
-                                    <v-col cols="2">
-                                        <v-btn v-if="!editActiveTarget" variant="flat" color="#E09D00" block
-                                            size="large" @click.stop="editActiveTarget = true">Edit</v-btn>
-                                        <v-btn v-if="editActiveTarget" variant="flat" color="#00ABC9" block size="large"
-                                            @click.stop="editActiveTarget = false">Confirm</v-btn>
-                                    </v-col>
-                                </v-row>
-
-                                <!-- If pending topic -->
-                                <v-text-field v-if="!topicFound(topicToAdd, activeTopics)" v-model="topicToAdd"
-                                    label="Topic" :rules="[rules.required, rules.topic]" />
-                            </v-col>
-                        </v-row>
-
-                        <v-row>
-                            <v-col cols="12">
-                                <v-text-field v-if="!topicFound(topicToAdd, activeTopics)" v-model="targetToAdd"
-                                    label="Associated Sub-Directory" :rules="[rules.required, rules.target]" />
-                            </v-col>
-                        </v-row>
-
-                        <v-row>
-                            <v-col cols="12">
-                                <!-- If an active target is being edited, you can't save -->
-                                <v-btn :disabled="editActiveTarget" type="submit" color="#003DA5" variant="flat" block
-                                    @click="saveTopic" :loading="makingServerRequest[topicToAdd]">Save</v-btn>
-                            </v-col>
-                        </v-row>
-                    </v-col>
+                    <v-btn type="submit" color="#003DA5" variant="flat" block @click="saveTopic"
+                        :loading="makingServerRequest[topicToAdd]">Save</v-btn>
                 </v-form>
-            </v-container>
+
+                <!-- Active topics -->
+                <v-form ref="form" v-if="!configuredTopicIsPending">
+                    <v-row v-if="topicFound(topicToAdd, activeTopics)" class="pb-5">
+                        <v-col cols="2">
+                            <p class="medium-title"><b>Topic:</b></p>
+                        </v-col>
+                        <v-col cols="10">
+                            <p class="medium-title">{{ topicToAdd }}</p>
+                        </v-col>
+                    </v-row>
+
+                    <v-divider />
+
+                    <v-row v-if="topicFound(topicToAdd, activeTopics)" class="pt-5">
+                        <v-col cols="2">
+                            <p class="medium-title"><b>Target:</b></p>
+                        </v-col>
+                        <v-col cols="8">
+                            <!-- Target switches between read-only and editable -->
+                            <p v-if="!editActiveTarget" class="medium-title">{{ targetToAdd }}</p>
+                            <v-text-field v-else v-model="targetToAdd" density="comfortable" variant="outlined"
+                                clearable :rules="[rules.required, rules.target]" />
+                        </v-col>
+                        <v-col cols="2">
+                            <v-btn v-if="!editActiveTarget" variant="flat" color="#E09D00" block size="large"
+                                @click.stop="editActiveTarget = true">Edit</v-btn>
+                            <v-btn v-if="editActiveTarget" variant="flat" color="#00ABC9" block size="large"
+                                @click.stop="configureActiveTarget">Confirm</v-btn>
+                        </v-col>
+                    </v-row>
+
+                    <v-row>
+                        <v-col cols="12">
+                            <!-- If an active target is being edited, you can't save -->
+                            <v-btn :disabled="editActiveTarget" type="submit" color="#003DA5" variant="flat" block
+                                @click="saveTopic" :loading="makingServerRequest[topicToAdd]">Save</v-btn>
+                        </v-col>
+                    </v-row>
+                </v-form>
+            </v-sheet>
         </v-card>
     </v-dialog>
 
@@ -331,7 +324,9 @@
             <v-container v-else>
                 <v-row>
                     <v-col cols="12">
-                        <p class="medium-title text-center">No metrics to display, as no notifications have been received yet from this topic.</p>
+                        <p class="medium-title text-center">No metrics to display, as no notifications have been
+                            received
+                            yet from this topic.</p>
                     </v-col>
                 </v-row>
             </v-container>
@@ -425,7 +420,7 @@ export default defineComponent({
         const rules = {
             required: input => !!input || 'Field is required.',
             topic: input => {
-                if (topicFound(input, activeTopics.value) || 
+                if (topicFound(input, activeTopics.value) ||
                     (topicFound(input, pendingTopics.value) && isTopicNew.value)) {
                     return 'This topic is already added to or overlaps with an existing topic';
                 }
@@ -521,11 +516,13 @@ export default defineComponent({
 
         // Topic configuration dialog
         const showTopicConfigDialog = ref(false);
+        const configuredTopicIsPending = ref(false);
         const topicDialogTitle = ref('Create New Topic');
         const isTopicNew = ref(true);
         const previousTopic = ref('');
         const previousTarget = ref('');
         const editActiveTarget = ref(false);
+        const form = ref(false);
 
         // Topic metric monitoring dialog
         const showTopicMonitorDialog = ref(false);
@@ -831,7 +828,9 @@ export default defineComponent({
         };
 
         // Configure pending topic and target
-        const configureTopic = (item) => {
+        const configureTopic = (state, item) => {
+            configuredTopicIsPending.value = state === 'pending';
+
             showTopicConfigDialog.value = true;
 
             if (!item) {
@@ -850,8 +849,25 @@ export default defineComponent({
             populateFields(item);
         };
 
+        const configureActiveTarget = async () => {
+            // First check if the content is valid
+            const { valid } = await form.value.validate();
+            if (!valid) {
+                return;
+            }
+
+            // Save the new target
+            editActiveTarget.value = false;
+        }
+
         // Adds or updates the topic, both in the list of active topics and pending topics
         const saveTopic = async () => {
+            // First check if the content is valid
+            const { valid } = await form.value.validate();
+            if (!valid) {
+                return;
+            }
+
             const isActive = topicFound(topicToAdd.value, activeTopics.value);
 
             if (isActive) {
@@ -1083,8 +1099,10 @@ export default defineComponent({
             makingServerRequest,
             lastSyncTime,
             showTopicConfigDialog,
+            configuredTopicIsPending,
             topicDialogTitle,
             editActiveTarget,
+            form,
             showTopicMonitorDialog,
             monitorDialogTitle,
             topicMetrics,
@@ -1108,6 +1126,7 @@ export default defineComponent({
             monitorTopic,
             topicFound,
             configureTopic,
+            configureActiveTarget,
             saveTopic,
             addToSubscription,
             addAllToSubscription,
@@ -1122,10 +1141,11 @@ export default defineComponent({
 </script>
 
 <style scoped>
-
-.equal-width th, .equal-width td {
+.equal-width th,
+.equal-width td {
     width: 33%;
-    word-break: break-word; /* Ensure long words wrap */
+    word-break: break-word;
+    /* Ensure long words wrap */
 }
 
 /* Misc. */

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -423,20 +423,21 @@ export default defineComponent({
 
         // Static variables
         const rules = {
-            required: value => !!value || 'Field is required.',
-            topic: value => {
-                if (topicFound(value, activeTopics.value) || topicFound(value, pendingTopics.value)) {
+            required: input => !!input || 'Field is required.',
+            topic: input => {
+                if (topicFound(input, activeTopics.value) || 
+                    (topicFound(input, pendingTopics.value) && isTopicNew.value)) {
                     return 'This topic is already added to or overlaps with an existing topic';
                 }
             },
-            target: value => {
+            target: input => {
                 // Check if the target is exactly "$TOPIC"
-                if (value === "$TOPIC") {
+                if (input === "$TOPIC") {
                     return true;
                 }
                 // Regular expression for whitelisted characters
                 const validPattern = /^[A-Za-z0-9/_-]+$/;
-                return validPattern.test(value) || 'Invalid target';
+                return validPattern.test(input) || 'Invalid target';
             }
         };
 
@@ -521,6 +522,7 @@ export default defineComponent({
         // Topic configuration dialog
         const showTopicConfigDialog = ref(false);
         const topicDialogTitle = ref('Create New Topic');
+        const isTopicNew = ref(true);
         const previousTopic = ref('');
         const previousTarget = ref('');
         const editActiveTarget = ref(false);
@@ -833,9 +835,11 @@ export default defineComponent({
             showTopicConfigDialog.value = true;
 
             if (!item) {
+                isTopicNew.value = true;
                 topicDialogTitle.value = 'Create New Topic';
             }
             else {
+                isTopicNew.value = false;
                 topicDialogTitle.value = 'Edit Topic';
             }
 
@@ -1093,7 +1097,6 @@ export default defineComponent({
             // Computed variables
             settings,
             topicHasMetrics,
-            subscribeLink,
 
             // Methods
             processTopicData,

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -230,13 +230,13 @@
             <v-sheet class="mx-auto py-5" width="95%">
                 <!-- Pending topics -->
                 <v-form ref="form" v-if="configuredTopicIsPending">
-                    <v-text-field v-model="topicToAdd" label="Topic" :rules="[rules.required, rules.topic]" />
+                    <v-text-field v-model="topicToAdd" label="Topic" :rules="[rules.required, rules.topic]" class="my-2"/>
 
                     <v-text-field v-model="targetToAdd" label="Associated Sub-Directory"
-                        :rules="[rules.required, rules.target]" />
+                        :rules="[rules.required, rules.target]" class="my-2"/>
 
                     <v-btn type="submit" color="#003DA5" variant="flat" block @click="saveTopic"
-                        :loading="makingServerRequest[topicToAdd]">Save</v-btn>
+                        :loading="makingServerRequest[topicToAdd]" class="mt-2">Save</v-btn>
                 </v-form>
 
                 <!-- Active topics -->
@@ -272,8 +272,8 @@
 
                     <v-row>
                         <v-col cols="12">
-                            <!-- If an active target is being edited, you can't save -->
-                            <v-btn :disabled="editActiveTarget" type="submit" color="#003DA5" variant="flat" block
+                            <!-- If an active target hasn't changed or is being edited, you can't save -->
+                            <v-btn :disabled="!canSaveActiveChanges" type="submit" color="#003DA5" variant="flat" block
                                 @click="saveTopic" :loading="makingServerRequest[topicToAdd]">Save</v-btn>
                         </v-col>
                     </v-row>
@@ -552,6 +552,11 @@ export default defineComponent({
         // Build subscription URL from the server link
         const subscribeLink = computed(() => {
             return `${serverLink.value}/subscriptions`;
+        });
+
+        // Check if the active topic configuration can be saved
+        const canSaveActiveChanges = computed(() => {
+            return targetToAdd.value !== previousTarget.value && targetToAdd.value !== '' && !editActiveTarget.value;
         });
 
         // Check if the topic has metrics to display
@@ -880,7 +885,10 @@ export default defineComponent({
                 };
 
                 await addToSubscription(updatedItem);
-                // Close the dialog
+
+                // Reset the input fields and close the dialog
+                topicToAdd.value = '';
+                targetToAdd.value = '';
                 showTopicConfigDialog.value = false;
                 return;
             }
@@ -1114,6 +1122,7 @@ export default defineComponent({
 
             // Computed variables
             settings,
+            canSaveActiveChanges,
             topicHasMetrics,
 
             // Methods


### PR DESCRIPTION
**Major Fixes**
- Pending dialog no longer switches to active dialog when the input topic intersects with an active topic.
- User cannot save if the validation of the text fields fails.

**Minor Fixes**
- Downloader connection state boolean is renamed in `CatalogueView.vue`.
- Server link now defaults with a `http://` prefix.
- User cannot save changes to an active topic's target if no changes were made.