### PR TITLE
fix: GDC API endpoints and error handling

### DIFF
--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -270,7 +270,7 @@ export default defineComponent({
         // Helper function to fetch API data
         const fetchAPI = async (url, params) => {
             try {
-                const response = await fetch(`${url}?${params}`);
+                const response = await fetch(`${url}&${params}`);
                 if (!response.ok) {
                     const readableError = HTTP_CODES[response.status] || response.statusText;
                     throw new Error(`There was an error connecting to the catalogue: ${readableError}`);

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -34,13 +34,13 @@
                 <!-- Dialog to display typical error messages -->
                 <v-dialog v-model="showErrorDialog" max-width="600px" persistent>
                     <v-card>
-                        <v-toolbar :title="errorTitle" color="#003DA5">
+                        <v-toolbar :title="errorTitle" color="error">
                         </v-toolbar>
                         <v-card-text>
                             {{ errorMessage }}
                         </v-card-text>
                         <v-card-actions>
-                            <v-btn color="#003DA5" block @click="showErrorDialog = false">
+                            <v-btn color="black" variant="flat" block @click="showErrorDialog = false">
                                 OK
                             </v-btn>
                         </v-card-actions>
@@ -277,7 +277,7 @@ export default defineComponent({
                 }
                 return await response.json();
             } catch (error) {
-                throw new Error(`There was an error connecting to the catalogue: ${error.message}`);
+                throw new Error(error.message);
             }
         };
 
@@ -574,6 +574,7 @@ export default defineComponent({
             connectedToDownloader,
             activeTopics,
             pendingTopics,
+            errorTitle,
             errorMessage,
             showErrorDialog,
 

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -187,7 +187,7 @@ export default defineComponent({
 
         // Static variables
         const catalogueList = [
-            { title: 'Meteorological Service of Canada', url: 'https://api.weather.gc.ca/collections/wis2-discovery-metadata/items' },
+            { title: 'Meteorological Service of Canada', url: 'https://api.weather.gc.ca/collections/wis2-discovery-metadata/items?f=json' },
             { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/collections/wis2-discovery-metadata/items?f=json' }
         ];
 
@@ -212,6 +212,7 @@ export default defineComponent({
         const pendingTopics = ref([]);
 
         // Error from the catalogue
+        const errorTitle = ref('');
         const errorMessage = ref('');
         const showErrorDialog = ref(false);
 

--- a/src/frontend/layouts/default/AppBar.vue
+++ b/src/frontend/layouts/default/AppBar.vue
@@ -44,7 +44,6 @@ export default defineComponent({
     // Check if the OS is Darwin
     const checkOS = async () => {
       const platform = await window.electronAPI.getOS();
-      console.log(platform)
       isDarwin.value = (platform === 'darwin');
     };
 


### PR DESCRIPTION
This branch was intended to solve the issue of the China GDC returning an error when fetched. However, it turns out that this GDC does not have CORS enabled so is out of our control.

**Minor Changes**
- Error title variable is now correctly initialised.
- The JSON endpoint (`?f=json`) is now used for both the Canada and China GDC and is corrected to use an ampersand when querying.