### PR TITLE
Feature: Scrollbar and metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wis2-subscription-manager",
-  "version": "0.3.0-dev",
+  "version": "0.3.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wis2-subscription-manager",
   "productName": "WIS2 Subscription Manager",
-  "version": "0.3.0-dev",
+  "version": "0.3.1-dev",
   "description": "This standalone application allows you to browse a WIS2 Global Discovery Catalogue, configure WIS2 subscriptions, and view download metrics.",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -12,8 +12,6 @@
                     If you have not yet connected to a WIS2 Downloader, you will only be able to view the datasets.
                 </v-card-subtitle>
 
-                {{ pendingTopics }}
-
                 <v-card-item>
                     <v-row dense>
                         <v-col cols="5">

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -79,7 +79,7 @@
                         <thead>
                             <tr>
                                 <th scope="row" class="topic-column">
-                                    <p class="medium-title">Discovery Metadata Records Found: <b class="hint-default">{{ datasets.length }}</b></p> 
+                                    <p class="medium-title">Discovery Metadata Records Found: <b v-if="tableBoolean" class="hint-default">{{ datasets.length }}</b></p> 
                                 </th>
                                 <th scope="row" class="button-column">
                                     <v-row justify="center" class="pa-2"

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -72,13 +72,16 @@
                                     <td class="small-title py-3">
                                         <div class="title-section">
                                             <span><b v-if="item.centre_identifier">{{ item.centre_identifier }}:</b> {{ item.title }}</span>
-                                            <span class="policy-section">({{ item.data_policy }})</span>
+                                            <v-chip class="policy-section">{{ item.data_policy }}</v-chip>
                                         </div>
                                         <div class="description-section">
                                             <p>{{ item.description.substring(0, 120) + '...' }}</p>
                                         </div>
                                         <div class="keywords-section">
                                             <p><b>Keywords:</b> {{ item.keywords }}</p>
+                                        </div>
+                                        <div class="country-section">
+                                            <p><b>Country:</b> {{ item.country }}</p>
                                         </div>
                                         <div class="date-section">
                                             <p><b>Creation Date:</b> {{ item.creation_date }}</p>
@@ -188,7 +191,7 @@ export default defineComponent({
         // Static variables
         const catalogueList = [
             { title: 'Meteorological Service of Canada', url: 'https://api.weather.gc.ca/collections/wis2-discovery-metadata/items?f=json' },
-            { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/collections/wis2-discovery-metadata/items?f=json' }
+            { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/api/collections/wis2-discovery-metadata/items?f=json' }
         ];
 
         // Reactive variables
@@ -371,6 +374,7 @@ export default defineComponent({
                     identifier: identifier,
                     centre_identifier: centre_id,
                     title: properties?.title,
+                    country: properties.contacts?.[0]?.addresses?.[0]?.country,
                     creation_date: properties?.created,
                     last_update: properties?.updated,
                     topic_hierarchy: topic_hierarchy,
@@ -621,6 +625,12 @@ export default defineComponent({
     font-size: 0.75rem;
     color: #555;
     font-style: italic;
+}
+
+.country-section {
+    margin-top: 0.5rem;
+    font-size: 0.75rem;
+    color: #555;
 }
 
 .date-section {

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -75,7 +75,7 @@
 
                 <!-- Display catalogue datasets searched by user -->
                 <v-card-item>
-                    <v-table :hover="true">
+                    <v-table :hover="true" class="scrollable-results">
                         <thead>
                             <tr>
                                 <th scope="row" class="topic-column">
@@ -93,6 +93,14 @@
                         </thead>
                         <transition name="slide-y-transition">
                             <tbody v-show="tableBoolean === true">
+                                <!-- Inform user if search returned nothing -->
+                                <tr v-if="datasets.length === 0">
+                                    <td class="small-title py-3">
+                                        <p>No datasets found. Please try a different search.</p>
+                                    </td>
+                                    <td></td>
+                                </tr>
+                                <!-- If datasets found, display them -->
                                 <tr v-for="item in datasets" :key="`${item.title}-${item.creation_date}`"
                                     @click="openDialog(item)" class="clickable-row">
                                     <td class="small-title py-3">
@@ -721,7 +729,12 @@ export default defineComponent({
 }
 
 .scrollable-table {
-    max-height: 600px;
+    max-height: 50rem;
+    overflow-y: auto;
+}
+
+.scrollable-results {
+    max-height: 60vh;
     overflow-y: auto;
 }
 </style>

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -27,10 +27,31 @@
                         </v-col>
                     </v-row>
 
-                    <v-row>
-                        <v-col cols="12">
+                    <!-- Most screens -->
+                    <v-row align="center" v-if="mdAndUp">
+                        <v-col cols="4">
+                            <v-divider/>
+                        </v-col>
+                        <v-col cols="4">
                             <v-btn @click="searchCatalogue" append-icon="mdi-cloud-search" color="#003DA5"
-                                variant="flat" block :disabled="!catalogueBoolean" :loading="loadingBoolean">Browse the Catalogue</v-btn>
+                                variant="flat" size="large" block :disabled="!catalogueBoolean" :loading="loadingBoolean">Browse the Catalogue</v-btn>
+                        </v-col>
+                        <v-col cols="4">
+                            <v-divider/>
+                        </v-col>
+                    </v-row>
+
+                    <!-- Very small screens -->
+                    <v-row align="center" v-if="!mdAndUp">
+                        <v-col cols="3">
+                            <v-divider/>
+                        </v-col>
+                        <v-col cols="6">
+                            <v-btn @click="searchCatalogue" append-icon="mdi-cloud-search" color="#003DA5"
+                                variant="flat" size="large" block :disabled="!catalogueBoolean" :loading="loadingBoolean">Browse the Catalogue</v-btn>
+                        </v-col>
+                        <v-col cols="3">
+                            <v-divider/>
                         </v-col>
                     </v-row>
 
@@ -172,7 +193,7 @@
 <script>
 import { defineComponent, ref, computed, watch, onMounted } from 'vue';
 import { VCard, VCardTitle, VCardText, VCardItem, VForm, VBtn, VListGroup, VSelect, VTextField, VTable, VDatePicker, VDivider } from 'vuetify/lib/components/index.mjs';
-import { useDate } from 'vuetify';
+import { useDisplay } from 'vuetify';
 
 // Sub-components
 import BboxView from "@/components/sub-components/BboxView.vue";
@@ -210,6 +231,9 @@ export default defineComponent({
             { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/api/collections/wis2-discovery-metadata/items' }
         ];
         const limitOptions = [10, 100, 500, 1000];
+
+        // Breakpoints
+        const { smAndUp, mdAndUp, lgAndUp } = useDisplay();
 
         // Reactive variables
 
@@ -604,6 +628,9 @@ export default defineComponent({
             // Static variables
             catalogueList,
             limitOptions,
+            smAndUp,
+            mdAndUp,
+            lgAndUp,
 
             // Reactive variables
             selectedCatalogue,

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -12,6 +12,8 @@
                     If you have not yet connected to a WIS2 Downloader, you will only be able to view the datasets.
                 </v-card-subtitle>
 
+                {{ pendingTopics }}
+
                 <v-card-item>
                     <v-row dense>
                         <v-col cols="5">
@@ -167,7 +169,7 @@
                                         <v-btn block
                                             v-if="topicFound(item.topic_hierarchy, pendingTopics) && connectedToDownloader"
                                             color="error" append-icon="mdi-minus" variant="flat"
-                                            @click.stop="removeTopicFromPending(item)">
+                                            @click.stop="removeTopicFromPending(item.topic_hierarchy)">
                                             Remove</v-btn>
                                         <v-btn block v-if="topicFound(item.topic_hierarchy, activeTopics)" disabled
                                             color="#003DA5" append-icon="mdi-download-multiple" variant="flat">
@@ -183,10 +185,10 @@
                 </transition>
 
                 <!-- Dialog to display dataset metadata -->
-                <v-dialog v-model="dialog" transition="scroll-y-transition" class="max-dataset-width">
+                <v-dialog v-model="featureDialog" transition="scroll-y-transition" class="max-dataset-width">
                     <v-card class="overflow-hidden">
                         <v-toolbar :title="selectedItem.title" color="#003DA5">
-                            <v-btn icon="mdi-close" variant="text" @click="dialog = false" />
+                            <v-btn icon="mdi-close" variant="text" @click="featureDialog = false" />
                         </v-toolbar>
                         <div class="scrollable-table">
                             <v-container class="pa-8">
@@ -295,7 +297,7 @@ export default defineComponent({
         const tableBoolean = ref(false);
         const addAllTopics = ref(false);
         const selectedItem = ref(null);
-        const dialog = ref(false);
+        const featureDialog = ref(false);
         const formattedJson = ref(null);
         const loadingJsonBoolean = ref(false);
         const jsonDialog = ref(false);
@@ -538,7 +540,7 @@ export default defineComponent({
         // Open the dialog to display dataset metadata
         const openDialog = (item) => {
             selectedItem.value = item;
-            dialog.value = true;
+            featureDialog.value = true;
         }
 
         // Format the key to be more readable
@@ -641,17 +643,11 @@ export default defineComponent({
 
             const updatedTopics = [...pendingTopics.value, toAdd];
             pendingTopics.value = updatedTopics;
-
-            // Close the dialog
-            dialog.value = false;
         }
 
         // When the user clicks 'Remove dataset from subscription', remove
         // the associated topic from the array which will be parsed to the Electron API
-        const removeTopicFromPending = (item) => {
-            const topicToRemove = item.topic_hierarchy;
-
-            // Check if there is any topic hierarchy associated with the dataset
+        const removeTopicFromPending = (topicToRemove) => {
             if (!topicToRemove) {
                 return;
             }
@@ -663,13 +659,10 @@ export default defineComponent({
                 handleError('Error Removing Topic', 'The topic was not found in the subscription');
                 return;
             }
-
+            
             let updatedTopics = [...pendingTopics.value];
-            updatedTopics = updatedTopics.filter(item => item !== topicToRemove);
+            updatedTopics = updatedTopics.filter(item => item.topic !== topicToRemove);
             pendingTopics.value = updatedTopics;
-
-            // Close the dialog
-            dialog.value = false;
         };
 
         // Toggles the selection of all topics
@@ -721,7 +714,7 @@ export default defineComponent({
             tableBoolean,
             addAllTopics,
             selectedItem,
-            dialog,
+            featureDialog,
             formattedJson,
             loadingJsonBoolean,
             jsonDialog,

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -79,7 +79,7 @@
                         <thead>
                             <tr>
                                 <th scope="row" class="topic-column">
-                                    <p class="medium-title">Discovery Metadata Records Found</p>
+                                    <p class="medium-title">Discovery Metadata Records Found: <b class="hint-default">{{ datasets.length }}</b></p> 
                                 </th>
                                 <th scope="row" class="button-column">
                                     <v-row justify="center" class="pa-2"
@@ -107,7 +107,7 @@
                                         <div class="title-section">
                                             <span><b v-if="item.centre_identifier">{{ item.centre_identifier }}:</b> {{
                                 formatValue(item.title) }}</span>
-                                            <v-chip class="policy-section">{{ formatValue(item.data_policy) }}</v-chip>
+                                            <v-chip class="policy-section" label>{{ formatValue(item.data_policy) }}</v-chip>
                                         </div>
                                         <div class="description-section">
                                             <p>{{ item.description.substring(0, 120) + '...' }}</p>

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -30,28 +30,30 @@
                     <!-- Most screens -->
                     <v-row align="center" v-if="mdAndUp">
                         <v-col cols="4">
-                            <v-divider/>
+                            <v-divider />
                         </v-col>
                         <v-col cols="4">
                             <v-btn @click="searchCatalogue" append-icon="mdi-cloud-search" color="#003DA5"
-                                variant="flat" size="large" block :disabled="!catalogueBoolean" :loading="loadingBoolean">Browse the Catalogue</v-btn>
+                                variant="flat" size="large" block :disabled="!catalogueBoolean"
+                                :loading="loadingBoolean">Browse the Catalogue</v-btn>
                         </v-col>
                         <v-col cols="4">
-                            <v-divider/>
+                            <v-divider />
                         </v-col>
                     </v-row>
 
                     <!-- Very small screens -->
                     <v-row align="center" v-if="!mdAndUp">
                         <v-col cols="3">
-                            <v-divider/>
+                            <v-divider />
                         </v-col>
                         <v-col cols="6">
                             <v-btn @click="searchCatalogue" append-icon="mdi-cloud-search" color="#003DA5"
-                                variant="flat" size="large" block :disabled="!catalogueBoolean" :loading="loadingBoolean">Browse the Catalogue</v-btn>
+                                variant="flat" size="large" block :disabled="!catalogueBoolean"
+                                :loading="loadingBoolean">Browse the Catalogue</v-btn>
                         </v-col>
                         <v-col cols="3">
-                            <v-divider/>
+                            <v-divider />
                         </v-col>
                     </v-row>
 
@@ -74,24 +76,27 @@
                 </v-dialog>
 
                 <!-- Display catalogue datasets searched by user -->
-                <v-card-item>
-                    <v-table :hover="true" class="scrollable-results">
-                        <thead>
-                            <tr>
-                                <th scope="row" class="topic-column">
-                                    <p class="medium-title">Discovery Metadata Records Found: <b v-if="tableBoolean" class="hint-default">{{ datasets.length }}</b></p> 
-                                </th>
-                                <th scope="row" class="button-column">
-                                    <v-row justify="center" class="pa-2"
-                                        v-if="tableBoolean === true && connectedToDownloader">
-                                        <v-switch inset label="Add All" v-model="addAllTopics"
-                                            @change="addOrRemoveAllTopics(datasets, addAllTopics)"
-                                            :disabled="tableBoolean === false" color="#003DA5" />
-                                    </v-row>
-                                </th>
-                            </tr>
-                        </thead>
-                        <transition name="slide-y-transition">
+                <transition name="slide-y-transition">
+                    <v-card-item class="scrollable-results">
+                        <v-banner v-if="tableBoolean === true" sticky class="py-0">
+                            <v-row>
+                                <v-col cols="9">
+                                    <p class="text-h5 font-weight-light">
+                                        Discovery Metadata Records Found:
+                                        <b v-if="tableBoolean" class="hint-default"> {{ datasets.length
+                                            }}</b>
+                                    </p>
+                                </v-col>
+
+                                <v-col v-if="connectedToDownloader" class="py-0 mr-3 d-flex justify-end">
+                                    <v-switch inset label="Add All" v-model="addAllTopics"
+                                        @change="addOrRemoveAllTopics(datasets, addAllTopics)"
+                                        :disabled="tableBoolean === false" color="#003DA5" />
+                                </v-col>
+                            </v-row>
+                        </v-banner>
+
+                        <v-table :hover="true">
                             <tbody v-show="tableBoolean === true">
                                 <!-- Inform user if search returned nothing -->
                                 <tr v-if="datasets.length === 0">
@@ -103,11 +108,13 @@
                                 <!-- If datasets found, display them -->
                                 <tr v-for="item in datasets" :key="`${item.title}-${item.creation_date}`"
                                     @click="openDialog(item)" class="clickable-row">
-                                    <td class="small-title py-3">
+                                    <td class="small-title topic-column py-3">
                                         <div class="title-section">
-                                            <span><b v-if="item.centre_identifier">{{ item.centre_identifier }}:</b> {{
+                                            <span><b v-if="item.centre_identifier">{{ item.centre_identifier }}:</b>
+                                                {{
                                 formatValue(item.title) }}</span>
-                                            <v-chip class="policy-section" label>{{ formatValue(item.data_policy) }}</v-chip>
+                                            <v-chip class="policy-section" label>{{ formatValue(item.data_policy)
+                                                }}</v-chip>
                                         </div>
                                         <div class="description-section">
                                             <p>{{ item.description.substring(0, 120) + '...' }}</p>
@@ -123,7 +130,7 @@
                                         </div>
                                     </td>
                                     <td>
-                                        <!-- If topic not added, allow them to add -->
+                                        <!-- Buttons to add, remove, or show topic status -->
                                         <v-btn block
                                             v-if="!topicFound(item.topic_hierarchy, selectedTopics) && item.topic_hierarchy && connectedToDownloader"
                                             color="#64BF40" append-icon="mdi-plus" variant="flat"
@@ -143,56 +150,59 @@
                                     </td>
                                 </tr>
                             </tbody>
-                        </transition>
-                    </v-table>
+                            <!-- Scroll to top button -->
+                            <v-btn v-if="datasets.length > 5" color="#003DA5">
+                                <v-icon>mdi-arrow-up</v-icon>
+                            </v-btn>
+                        </v-table>
+                    </v-card-item>
+                </transition>
 
-                    <!-- Dialog to display dataset metadata -->
-                    <v-dialog v-model="dialog" transition="scroll-y-transition" class="max-dataset-width">
-                        <v-card class="overflow-hidden">
-                            <v-toolbar :title="selectedItem.title" color="#003DA5">
-                                <v-btn icon="mdi-close" variant="text" @click="dialog = false" />
-                            </v-toolbar>
-                            <div class="scrollable-table">
-                                <v-container class="pa-8">
-                                    <bbox-view :coordinates="selectedItem.coordinates" height="16rem"
-                                        id="map"></bbox-view>
-                                </v-container>
-                                <v-table class="px-4">
-                                    <tbody>
-                                        <tr v-for="([key, value], _) in filteredItems">
-                                            <td class="feature-column"><b>{{ formatKey(key) }}</b></td>
-                                            <td>{{ formatValue(value) }}</td>
-                                        </tr>
-                                    </tbody>
-                                </v-table>
-                            </div>
-                            <v-card-actions>
-                                <v-row>
-                                    <v-col cols="12">
-                                        <v-btn color="#E09D00" append-icon="mdi-code-json" variant="flat" block
-                                            @click="openJSON(selectedItem.identifier, selectedItem.title)"
-                                            :loading="loadingJsonBoolean">
-                                            View JSON
-                                        </v-btn>
-                                    </v-col>
-                                </v-row>
-                            </v-card-actions>
-                        </v-card>
-                    </v-dialog>
+                <!-- Dialog to display dataset metadata -->
+                <v-dialog v-model="dialog" transition="scroll-y-transition" class="max-dataset-width">
+                    <v-card class="overflow-hidden">
+                        <v-toolbar :title="selectedItem.title" color="#003DA5">
+                            <v-btn icon="mdi-close" variant="text" @click="dialog = false" />
+                        </v-toolbar>
+                        <div class="scrollable-table">
+                            <v-container class="pa-8">
+                                <bbox-view :coordinates="selectedItem.coordinates" height="16rem" id="map"></bbox-view>
+                            </v-container>
+                            <v-table class="px-4">
+                                <tbody>
+                                    <tr v-for="([key, value], _) in filteredItems">
+                                        <td class="feature-column"><b>{{ formatKey(key) }}</b></td>
+                                        <td>{{ formatValue(value) }}</td>
+                                    </tr>
+                                </tbody>
+                            </v-table>
+                        </div>
+                        <v-card-actions>
+                            <v-row>
+                                <v-col cols="12">
+                                    <v-btn color="#E09D00" append-icon="mdi-code-json" variant="flat" block
+                                        @click="openJSON(selectedItem.identifier, selectedItem.title)"
+                                        :loading="loadingJsonBoolean">
+                                        View JSON
+                                    </v-btn>
+                                </v-col>
+                            </v-row>
+                        </v-card-actions>
+                    </v-card>
+                </v-dialog>
 
-                    <!-- Dialog to display the whole JSON object -->
-                    <v-dialog v-model="jsonDialog" max-height="600px" max-width="1200px" scrollable
-                        transition="scale-transition">
-                        <v-card>
-                            <v-toolbar :title="selectedItem.title" color="#E09D00">
-                                <v-btn icon="mdi-close" variant="text" @click="jsonDialog = false" />
-                            </v-toolbar>
-                            <v-card-text>
-                                <pre class="wrap-text">{{ formattedJson }}</pre>
-                            </v-card-text>
-                        </v-card>
-                    </v-dialog>
-                </v-card-item>
+                <!-- Dialog to display the whole JSON object -->
+                <v-dialog v-model="jsonDialog" max-height="600px" max-width="1200px" scrollable
+                    transition="scale-transition">
+                    <v-card>
+                        <v-toolbar :title="selectedItem.title" color="#E09D00">
+                            <v-btn icon="mdi-close" variant="text" @click="jsonDialog = false" />
+                        </v-toolbar>
+                        <v-card-text>
+                            <pre class="wrap-text">{{ formattedJson }}</pre>
+                        </v-card-text>
+                    </v-card>
+                </v-dialog>
             </v-card>
         </v-col>
     </v-row>
@@ -358,7 +368,6 @@ export default defineComponent({
 
             for (const link of links || []) {
                 if (link.href.startsWith('mqtt')) {
-                    console.log('Link:', link)
                     for (const key in link) {
                         if (link[key].startsWith('cache/') || link[key].startsWith('origin/')) {
                             return link[key];
@@ -683,11 +692,7 @@ export default defineComponent({
 
 <style scoped>
 .topic-column {
-    width: 83%;
-}
-
-.button-column {
-    width: 17%;
+    width: 85%;
 }
 
 .title-section {

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -72,16 +72,13 @@
                                     <td class="small-title py-3">
                                         <div class="title-section">
                                             <span><b v-if="item.centre_identifier">{{ item.centre_identifier }}:</b> {{ item.title }}</span>
-                                            <v-chip class="policy-section">{{ item.data_policy }}</v-chip>
+                                            <span class="policy-section">({{ item.data_policy }})</span>
                                         </div>
                                         <div class="description-section">
                                             <p>{{ item.description.substring(0, 120) + '...' }}</p>
                                         </div>
                                         <div class="keywords-section">
                                             <p><b>Keywords:</b> {{ item.keywords }}</p>
-                                        </div>
-                                        <div class="country-section">
-                                            <p><b>Country:</b> {{ item.country }}</p>
                                         </div>
                                         <div class="date-section">
                                             <p><b>Creation Date:</b> {{ item.creation_date }}</p>
@@ -191,7 +188,7 @@ export default defineComponent({
         // Static variables
         const catalogueList = [
             { title: 'Meteorological Service of Canada', url: 'https://api.weather.gc.ca/collections/wis2-discovery-metadata/items?f=json' },
-            { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/api/collections/wis2-discovery-metadata/items?f=json' }
+            { title: 'China Meteorological Administration', url: 'https://gdc.wis.cma.cn/collections/wis2-discovery-metadata/items?f=json' }
         ];
 
         // Reactive variables
@@ -374,7 +371,6 @@ export default defineComponent({
                     identifier: identifier,
                     centre_identifier: centre_id,
                     title: properties?.title,
-                    country: properties.contacts?.[0]?.addresses?.[0]?.country,
                     creation_date: properties?.created,
                     last_update: properties?.updated,
                     topic_hierarchy: topic_hierarchy,
@@ -625,12 +621,6 @@ export default defineComponent({
     font-size: 0.75rem;
     color: #555;
     font-style: italic;
-}
-
-.country-section {
-    margin-top: 0.5rem;
-    font-size: 0.75rem;
-    color: #555;
 }
 
 .date-section {

--- a/src/frontend/components/CatalogueView.vue
+++ b/src/frontend/components/CatalogueView.vue
@@ -77,8 +77,21 @@
 
                 <!-- Display catalogue datasets searched by user -->
                 <transition name="slide-y-transition">
-                    <v-card-item class="scrollable-results">
-                        <v-banner v-if="tableBoolean === true" sticky class="py-0">
+                    <v-card-item class="scrollable-results" v-scroll.self="onScroll">
+                        <!-- Scroll to top button -->
+                        <v-row>
+                            <v-col cols="12">
+                                <div class="overlay-container">
+                                    <v-fade-transition>
+                                        <v-btn v-if="offsetTop > 500" class="overlay-button" color="#003DA5" icon="mdi-arrow-up"
+                                            @click="toTop" />
+                                    </v-fade-transition>
+                                </div>
+                            </v-col>
+                        </v-row>
+
+                        <!-- Table title -->
+                        <v-banner v-if="tableBoolean === true" sticky class="pt-0 pb-3" id="top-banner">
                             <v-row>
                                 <v-col cols="9">
                                     <p class="text-h5 font-weight-light">
@@ -96,6 +109,7 @@
                             </v-row>
                         </v-banner>
 
+                        <!-- Search results -->
                         <v-table :hover="true">
                             <tbody v-show="tableBoolean === true">
                                 <!-- Inform user if search returned nothing -->
@@ -150,10 +164,6 @@
                                     </td>
                                 </tr>
                             </tbody>
-                            <!-- Scroll to top button -->
-                            <v-btn v-if="datasets.length > 5" color="#003DA5">
-                                <v-icon>mdi-arrow-up</v-icon>
-                            </v-btn>
                         </v-table>
                     </v-card-item>
                 </transition>
@@ -241,7 +251,7 @@ export default defineComponent({
         // Deep clone function to avoid reference issues between model and default model
         function deepClone(obj) {
             return JSON.parse(JSON.stringify(obj));
-        }
+        };
 
         // Static variables
         const catalogueList = [
@@ -254,6 +264,9 @@ export default defineComponent({
         const { smAndUp, mdAndUp, lgAndUp } = useDisplay();
 
         // Reactive variables
+
+        // Scroll
+        const offsetTop = ref(0);
 
         // Catalogue query variables
         const selectedCatalogue = ref('');
@@ -312,6 +325,15 @@ export default defineComponent({
         });
 
         // Methods
+
+        // Scroll to top button
+        const onScroll = (e) => {
+            offsetTop.value = e.target.scrollTop;
+        };
+        const toTop = () => {
+            const element = document.getElementById("top-banner");
+            element.scrollIntoView({ block: 'end', behavior: 'smooth' });
+        };
 
         // Handle errors displayed to user
         const handleError = (title, message) => {
@@ -650,6 +672,7 @@ export default defineComponent({
             lgAndUp,
 
             // Reactive variables
+            offsetTop,
             selectedCatalogue,
             query,
             limit,
@@ -675,6 +698,8 @@ export default defineComponent({
             filteredItems,
 
             // Methods
+            onScroll,
+            toTop,
             searchCatalogue,
             openDialog,
             formatKey,
@@ -741,5 +766,17 @@ export default defineComponent({
 .scrollable-results {
     max-height: 60vh;
     overflow-y: auto;
+}
+
+.overlay-container {
+  position: relative;
+  height: 0vh;
+  display: flex;
+  justify-content: center;
+}
+
+.overlay-button {
+    position: fixed;
+    z-index: 10;
 }
 </style>

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -438,6 +438,7 @@ export default defineComponent({
             }
         };
 
+        // Breakpoints
         const { mdAndUp, lgAndUp } = useDisplay();
 
         // Bar chart options

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -85,7 +85,7 @@
                                     </v-col>
                                 </v-row>
                                 <v-card-item>
-                                    <v-table :hover="true" class="equal-width">
+                                    <v-table :hover="true" class="topic-table equal-width">
                                         <thead>
                                             <tr>
                                                 <th scope="row">
@@ -145,7 +145,7 @@
                                     downloader</v-card-subtitle>
 
                                 <v-card-item>
-                                    <v-table :hover="true" class="equal-width">
+                                    <v-table :hover="true" class="topic-table equal-width">
                                         <thead>
                                             <tr>
                                                 <th scope="row">
@@ -1202,5 +1202,10 @@ export default defineComponent({
     color: #666;
     opacity: 0.75;
     font-size: 1.1em;
+}
+
+.topic-table {
+    max-height: 400px;
+    overflow-y: auto;
 }
 </style>

--- a/src/frontend/components/ConfigSub.vue
+++ b/src/frontend/components/ConfigSub.vue
@@ -349,6 +349,10 @@
                 <p>{{ removalMessage }}</p>
             </v-card-text>
             <v-card-actions>
+                
+                <v-col cols="6">
+                    <v-btn color="black" variant="flat" block @click="showRemoveWarningDialog = false">No</v-btn>
+                </v-col>
                 <v-col cols="6">
                     <!-- Pending topic 'Yes' button -->
                     <v-btn v-if="topicFound(topicToRemove, pendingTopics)" color="error" variant="flat" block
@@ -357,9 +361,6 @@
                     <v-btn v-if="topicFound(topicToRemove, activeTopics)" color="error" variant="flat" block
                         @click="removeFromSubscription(topicToRemove)"
                         :loading="makingServerRequest[topicToRemove]">Yes</v-btn>
-                </v-col>
-                <v-col cols="6">
-                    <v-btn color="black" variant="flat" block @click="showRemoveWarningDialog = false">No</v-btn>
                 </v-col>
             </v-card-actions>
         </v-card>

--- a/src/frontend/styles/settings.scss
+++ b/src/frontend/styles/settings.scss
@@ -9,7 +9,7 @@
 //   $color-pack: false
 // );
 .max-form-width {
-    max-width: 1400px;
+    max-width: 1500px;
 }
 
 .max-table-width {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -9,7 +9,7 @@ if (require("electron-squirrel-startup")) {
 const createWindow = () => {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 1000,
+    width: 1200,
     height: 800,
     icon: "public/assets/logo-circle",
     titleBarStyle: 'hidden',


### PR DESCRIPTION
**Major Changes**
- GDC results now have a scroll bar and a scroll-to-top button that appears after scrolling down sufficiently.
- Users can now order GDC results by latest or oldest creation dates and filter results by datasets with a topic.
The downloaded bytes section of the topic monitoring page now automatically scales from bytes to KB, MB, and GB, and the associated title is updated accordingly.

**Minor Changes**
- The tables of pending and active topics in the Subscribe page now have a scroll bar.
- Fixed the bug where topics could not be removed from the Explore page.